### PR TITLE
Added support for multiple bot instances in one application

### DIFF
--- a/src/Mond.ts
+++ b/src/Mond.ts
@@ -13,9 +13,13 @@ export default class Mond {
     public logger: Logger;
     private configValid = false;
     private configLoaded = false;
+
     public static config: MondConfig = {
         logger: {},
+        embeds: {},
     };
+
+    public instanceConfig = Mond.config;
 
     private configName = "mond.config.json";
 
@@ -36,7 +40,7 @@ export default class Mond {
             : new Logger({
                   transports: [
                       {
-                          module: new PrettyConsoleTransport(Mond.config.logger),
+                          module: new PrettyConsoleTransport(this.instanceConfig.logger),
                       },
                   ],
               });
@@ -146,6 +150,7 @@ export default class Mond {
         const config = fs.readFileSync(configPath, "utf8");
 
         try {
+            this.instanceConfig = JSON.parse(config);
             Mond.config = JSON.parse(config);
             this.configValid = true;
         } catch (e) {

--- a/src/Mond.ts
+++ b/src/Mond.ts
@@ -17,14 +17,17 @@ export default class Mond {
         logger: {},
     };
 
+    private configName = "mond.config.json";
+
     private client: DiscordClient;
     private rest: REST;
 
     private commands: Map<string, MondCommand> = new Map();
     private events: Map<string, MondEvent> = new Map();
 
-    constructor(logger?: Logger) {
+    constructor(logger?: Logger, configName?: string) {
         // Setup Config
+        if (configName) this.configName = configName;
         this.loadConfig();
 
         // Setup Logger
@@ -136,7 +139,7 @@ export default class Mond {
     }
 
     private loadConfig() {
-        const configPath = path.join(process.cwd(), "mond.config.json");
+        const configPath = path.join(process.cwd(), this.configName);
         if (!fs.existsSync(configPath)) return;
         this.configLoaded = true;
 

--- a/src/Mond.ts
+++ b/src/Mond.ts
@@ -15,6 +15,8 @@ export default class Mond {
     private configLoaded = false;
 
     public static config: MondConfig = {
+        clientIdKey: "MOND_CLIENT_ID",
+        tokenKey: "MOND_TOKEN",
         logger: {},
         embeds: {},
     };
@@ -53,7 +55,7 @@ export default class Mond {
         });
 
         // Create Discord REST
-        this.rest = new REST({ version: "10" }).setToken(process.env.MOND_TOKEN || "");
+        this.rest = new REST({ version: "10" }).setToken(process.env[this.instanceConfig.tokenKey || "MOND_TOKEN"] || "");
 
         // Warn if no config found or config is invalid
         if (!this.configLoaded) {
@@ -101,7 +103,7 @@ export default class Mond {
         } else {
             this.logger.info("Commands are outdated, deploying...");
             return this.rest
-                .put(Routes.applicationCommands(process.env.MOND_CLIENT_ID || ""), { body: commands })
+                .put(Routes.applicationCommands(process.env[this.instanceConfig.clientIdKey || "MOND_CLIENT_ID"] || ""), { body: commands })
                 .then(() => {
                     fs.writeFileSync(cachePath, JSON.stringify(commands));
                     this.logger.info("Commands deployed");

--- a/src/builders/MondEmbed.ts
+++ b/src/builders/MondEmbed.ts
@@ -8,13 +8,15 @@ export default class MondEmbed {
     private footerIcon: string | undefined;
     private authorString: string | undefined;
     private authorIcon: string | undefined;
+    private client: Mond | undefined;
 
-    constructor() {
+    constructor(client?: Mond) {
         this.embed = new DiscordEmbedBuilder();
+        if (client) this.client = client;
     }
 
     public setTitle(title: string, useFormat = true) {
-        const titleFormat = Mond.config?.embeds?.titleFormat || "{title}";
+        const titleFormat = (this.client?.instanceConfig || Mond.config).embeds?.titleFormat || "{title}";
         if (useFormat) {
             this.embed.setTitle(multiReplace(titleFormat, [["{title}", title]]));
         } else {
@@ -29,7 +31,7 @@ export default class MondEmbed {
     }
 
     public setFooter(footer: string, useFormat = true, additionalData?: { user?: User }) {
-        const footerFormat = Mond.config?.embeds?.footerFormat || "{footer}";
+        const footerFormat = (this.client?.instanceConfig || Mond.config).embeds?.footerFormat || "{footer}";
         if (useFormat) {
             this.footerString = multiReplace(footerFormat, [
                 ["{footer}", footer],

--- a/src/interfaces/config/MondConfig.ts
+++ b/src/interfaces/config/MondConfig.ts
@@ -2,6 +2,8 @@ import MondEmbedOptions from "./MondEmbedOptions";
 import MondLoggerConfig from "./MondLoggerConfig";
 
 export default interface MondConfig {
+    tokenKey?: string;
+    clientIdKey?: string;
     logger?: MondLoggerConfig;
     embeds?: MondEmbedOptions;
 }


### PR DESCRIPTION
At @blazingworks, we've encountered an issue where we couldn't host multiple bots in a single codebase/process.

This PR
- makes the config dynamic for each instance. A static config is still provided which is always equal to the last config parsed.
- adds the ability to provide a Mond instance to Embeds to make use of that instance's config. Else, the static config mentioned above is used.
- adds the ability to customize the default env keys for token `MOND_TOKEN` and client id `MOND_CLIENT_ID` 