### PR TITLE
Make filename for cache customizable

### DIFF
--- a/src/Mond.ts
+++ b/src/Mond.ts
@@ -17,6 +17,7 @@ export default class Mond {
     public static config: MondConfig = {
         clientIdKey: "MOND_CLIENT_ID",
         tokenKey: "MOND_TOKEN",
+        cacheFileName: ".mondcache",
         logger: {},
         embeds: {},
     };
@@ -92,7 +93,7 @@ export default class Mond {
         this.commands.forEach((command) => {
             commands.push(command.toJSON());
         });
-        const cachePath = path.join(process.cwd(), ".mondcache");
+        const cachePath = path.join(process.cwd(), this.instanceConfig.cacheFileName || ".mondcache");
         let cache = "";
         if (fs.existsSync(cachePath)) {
             cache = fs.readFileSync(cachePath, "utf8");

--- a/src/interfaces/config/MondConfig.ts
+++ b/src/interfaces/config/MondConfig.ts
@@ -4,6 +4,7 @@ import MondLoggerConfig from "./MondLoggerConfig";
 export default interface MondConfig {
     tokenKey?: string;
     clientIdKey?: string;
+    cacheFileName?: string;
     logger?: MondLoggerConfig;
     embeds?: MondEmbedOptions;
 }


### PR DESCRIPTION
This PR adds a new config key that allows for customizing the filename of the Mond cache, useful mainly for multi-bot codebases.